### PR TITLE
Make room name comparison case agnostic

### DIFF
--- a/lib-gst-meet/src/conference.rs
+++ b/lib-gst-meet/src/conference.rs
@@ -508,7 +508,7 @@ impl StanzaFilter for JitsiConference {
       || element
         .attr("from")
         .and_then(|from| from.parse::<BareJid>().ok())
-        .map(|jid| jid == self.config.muc)
+        .map(|jid| jid.to_lowercase() == self.config.muc.to_lowercase())
         .unwrap_or_default()
         && (element.is("presence", ns::DEFAULT_NS) || element.is("iq", ns::DEFAULT_NS))
   }


### PR DESCRIPTION
When providing the room name as shown by Jitsi - e.g. "DarkSignsMobilizeExpectantly" - gst-meet will connect to the room but never proceed as the response(s) to send_presence contain the room name in lower case.